### PR TITLE
Add platforms and .env-based config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ __pycache__/
 *.sqlite3
 leadmanager/frontend/static/frontend/main.js
 leadmanager/frontend/static/frontend/
+
+# local configuration files
+leadmanager/.env

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Installation
 1. Clone this repository
 2. Python: `pip install requirements.txt` or `conda install --file requirements.txt`
 3. Node: `npm install`
-4. python manage.py createsuperuser
-5. login to `http://localhost:8000/admin` to administer users and groups
+4. Copy `.env.template` and edit it to enter in all your secret configuration variables
+5. python manage.py createsuperuser
+6. login to `http://localhost:8000/admin` to administer users and groups
 
 Running Database: 
 ----------------

--- a/leadmanager/.env.template
+++ b/leadmanager/.env.template
@@ -1,0 +1,13 @@
+# SECURITY WARNING: don't run with the debug turned on in production!
+DEBUG=True
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY=MY_RANDOM_SECRET_KEY_STR
+
+# Full URI to the primary database
+DATABASE_URI=sqlite:///db.sqlite
+
+# Platform-specific system tokens
+YOUTUBE_API_KEY=MY_YOUTUBE_API_KEY
+TWITTER_API_BEARER_TOKEN=MY_TWITTER_TOKEN
+MEDIA_CLOUD_API_KEY=MY_ADMIN_MC_KEY

--- a/leadmanager/leadmanager/settings.py
+++ b/leadmanager/leadmanager/settings.py
@@ -11,22 +11,23 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
 from pathlib import Path
+import os
+import dj_database_url
+import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+env = environ.Env(
+    DEBUG=(bool, False)  # set casting, default value
+)
+environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
+SECRET_KEY = env("SECRET_KEY")
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-ria&!9zz0v%!429-k5w)(ru_*7&w175fs86ha+v$ct_493uhm5"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = environ.Env(DEBUG=(bool, False))
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -37,12 +38,9 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "users",
     "rest_framework",
     "frontend",
     "rest_framework_simplejwt",
-
-
 ]
 
 MIDDLEWARE = [
@@ -76,21 +74,12 @@ TEMPLATES = [
 WSGI_APPLICATION = "leadmanager.wsgi.application"
 
 
-
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-    #"default": {
-    #    "ENGINE": "django.db.backends.postgresql",
-    #    "NAME": "django-react"
-    #}
+    "default": dj_database_url.parse(env('DATABASE_URI'), conn_max_age=600)
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
@@ -122,7 +111,6 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
-
 # Default primary key field type
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
 
@@ -136,3 +124,25 @@ REST_FRAMEWORK = {
     ]
 }
 
+APPEND_SLASH = False
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'DEBUG',
+    },
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
+        'LOCATION': '127.0.0.1:11211',
+    }
+}

--- a/leadmanager/platforms/__init__.py
+++ b/leadmanager/platforms/__init__.py
@@ -1,0 +1,68 @@
+import logging
+from typing import List
+import os
+import environ
+from pathlib import Path
+
+from .provider import ContentProvider
+from .reddit import RedditPushshiftProvider
+from .twitter import TwitterTwitterProvider
+from .youtube import YouTubeYouTubeProvider
+from .onlinenews import OnlineNewsMediaCloudProvider
+
+logger = logging.getLogger(__name__)
+
+# Load platform API keys
+BASE_DIR = Path(__file__).resolve().parent.parent
+env = environ.Env()
+environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
+YOUTUBE_API_KEY = env('YOUTUBE_API_KEY')
+TWITTER_API_BEARER_TOKEN = env('TWITTER_API_BEARER_TOKEN')
+MEDIA_CLOUD_API_KEY = env('MEDIA_CLOUD_API_KEY')
+
+# static list matching topics/info results
+PLATFORM_TWITTER = 'twitter'
+PLATFORM_REDDIT = 'reddit'
+PLATFORM_YOUTUBE = 'youtube'
+PLATFORM_ONLINE_NEWS = 'onlinenews'
+
+# static list matching topics/info results
+PLATFORM_SOURCE_PUSHSHIFT = 'pushshift'
+PLATFORM_SOURCE_TWITTER = 'twitter'
+PLATFORM_SOURCE_YOUTUBE = 'youtube'
+PLATFORM_SOURCE_MEDIA_CLOUD = 'mediacloud'
+
+
+def available_platforms() -> List[str]:
+    return [
+        PLATFORM_TWITTER + " / " + PLATFORM_SOURCE_TWITTER,
+        PLATFORM_REDDIT + " / " + PLATFORM_SOURCE_PUSHSHIFT,
+        PLATFORM_YOUTUBE + " / " + PLATFORM_SOURCE_YOUTUBE,
+        PLATFORM_ONLINE_NEWS + " / " + PLATFORM_SOURCE_MEDIA_CLOUD,
+    ]
+
+
+def provider_for(platform: str, source: str) -> ContentProvider:
+    """
+    A factory method that returns the appropriate data provider. Throws an exception to let you know if the
+    arguments are unsupported.
+    :param platform: One of the PLATFORM_* constants above.
+    :param source: One of the PLATFORM_SOURCE>* constants above.
+    :return:
+    """
+    if (platform == PLATFORM_TWITTER) and (source == PLATFORM_SOURCE_TWITTER):
+        platform_provider = TwitterTwitterProvider(TWITTER_API_BEARER_TOKEN)
+    elif (platform == PLATFORM_REDDIT) and (source == PLATFORM_SOURCE_PUSHSHIFT):
+        platform_provider = RedditPushshiftProvider()
+    elif (platform == PLATFORM_YOUTUBE) and (source == PLATFORM_SOURCE_YOUTUBE):
+        platform_provider = YouTubeYouTubeProvider(YOUTUBE_API_KEY)
+    elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_MEDIA_CLOUD):
+        platform_provider = OnlineNewsMediaCloudProvider(MEDIA_CLOUD_API_KEY)
+    else:
+        raise UnknownProviderException(platform, source)
+    return platform_provider
+
+
+class UnknownProviderException(Exception):
+    def __init__(self, platform, source):
+        super().__init__("Unknown provider {} from {}".format(platform, source))

--- a/leadmanager/platforms/exceptions.py
+++ b/leadmanager/platforms/exceptions.py
@@ -1,0 +1,3 @@
+
+class UnsupportedOperationException(Exception):
+    pass

--- a/leadmanager/platforms/onlinenews.py
+++ b/leadmanager/platforms/onlinenews.py
@@ -1,0 +1,119 @@
+import datetime as dt
+from typing import List, Dict
+import logging
+from mediacloud.api import MediaCloud
+
+from .provider import ContentProvider
+#from ..util.cache import cache_by_kwargs
+
+
+class OnlineNewsMediaCloudProvider(ContentProvider):
+
+    def __init__(self, api_key):
+        super(OnlineNewsMediaCloudProvider, self).__init__()
+        self._logger = logging.getLogger(__name__)
+        self._api_key = api_key
+        self._mc_client = MediaCloud(api_key)
+
+    #@cache_by_kwargs()
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
+               **kwargs) -> List[Dict]:
+        """
+        Return a list of stories matching the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param limit:
+        :param kwargs: sources and collections lists
+        :return:
+        """
+        q, fq = self._format_query(query, start_date, end_date, **kwargs)
+        story_list = self._mc_client.storyList(q, fq, rows=limit, **kwargs)
+        return story_list
+
+    #@cache_by_kwargs()
+    def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
+        """
+        Count how many verified tweets match the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs: sources and collections lists
+        :return:
+        """
+        q, fq = self._format_query(query, start_date, end_date, **kwargs)
+        story_count_result = self._mc_client.storyCount(q, fq, **kwargs)
+        return story_count_result['count']
+
+    #@cache_by_kwargs()
+    def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> List[Dict]:
+        """
+        How many verified tweets over time match the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs: sources and collections lists
+        :return:
+        """
+        q, fq = self._format_query(query, start_date, end_date, **kwargs)
+        story_count_result = self._mc_client.storyCount(q, fq, split=True)
+        return story_count_result
+
+    #@cache_by_kwargs()
+    def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
+              **kwargs) -> List[Dict]:
+        """
+        Get the top words based on a sample
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param limit:
+        :param kwargs: sources and collections lists
+        :return:
+        """
+        q, fq = self._format_query(query, start_date, end_date, **kwargs)
+        top_words = self._mc_client.wordCount(q, fq, **kwargs)[:limit]
+        return top_words
+
+    #@cache_by_kwargs()
+    def tags(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> List[Dict]:
+        q, fq = self._format_query(query, start_date, end_date, **kwargs)
+        tags_sets_id = kwargs.get('tags_sets_id', None)
+        sample_size = kwargs.get('sample_size', None)
+        top_tags = self._mc_client.storyTagCount(q, fq, tag_sets_id=tags_sets_id, limit=sample_size, http_method='POST')
+        return top_tags
+
+    @classmethod
+    def _format_query(cls, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                      **kwargs) -> (str, str):
+        """
+        Take all the query params and return q and fq suitable for a media cloud solr-syntax query
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs: sources and collections
+        :return:
+        """
+        media_ids = kwargs['sources'] if 'sources' in kwargs else []
+        tags_ids = kwargs['collections'] if 'collections' in kwargs else []
+        q = cls._query_from_parts(query, media_ids, tags_ids)
+        fq = MediaCloud.dates_as_query_clause(start_date, end_date)
+        return q, fq
+
+    @classmethod
+    def _query_from_parts(cls, query: str, media_ids: List[int], tag_ids: List[int]) -> str:
+        query = '({})'.format(query)
+        if len(media_ids) > 0 or (len(tag_ids) > 0):
+            clauses = []
+            # add in the media sources they specified
+            if len(media_ids) > 0: # this format is a string of media_ids
+                query_clause = "media_id:({})".format(" ".join([str(m) for m in media_ids]))
+                clauses.append(query_clause)
+            # add in the collections they specified
+            if len(tag_ids) > 0: # this format is a string of tags_id_medias
+                query_clause = "tags_id_media:({})".format(" ".join([str(m) for m in tag_ids]))
+                clauses.append(query_clause)
+            # now add in any addition media query clauses (get OR'd together)
+            if len(clauses) > 0:
+                query += " AND ({})".format(" OR ".join(clauses))
+        return query

--- a/leadmanager/platforms/provider.py
+++ b/leadmanager/platforms/provider.py
@@ -1,0 +1,57 @@
+import logging
+from typing import List, Dict
+import datetime as dt
+from .util import combined_split_and_normalized_counts
+
+# helpful for turning any date into the standard Media Cloud date format
+MC_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+class ContentProvider:
+    """
+    An abstract wrapper to be implemented for each platform we want to preview content from.
+    Any unimplemented methods raise an Exception
+    """
+
+    def __init__(self):
+        self._logger = logging.getLogger(__name__)
+
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
+               **kwargs) -> List[Dict]:
+        raise NotImplementedError("Subclasses should implement sample!")
+
+    def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
+        raise NotImplementedError("Subclasses should implement count!")
+
+    def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
+        raise NotImplementedError("Subclasses should implement count_over_time!")
+
+    def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
+              **kwargs) -> List[Dict]:
+        raise NotImplementedError("Subclasses should implement words!")
+
+    def normalized_count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                                   **kwargs) -> Dict:
+        """
+        Useful for rendering attention-over-time charts with extra information suitable for normalizing
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs:
+        :return:
+        """
+        matching_content_counts = self.count_over_time(query, start_date, end_date, **kwargs)['counts']
+        matching_total = sum([d['count'] for d in matching_content_counts])
+        no_query_content_counts = self.count_over_time(self._everything_query(), start_date, end_date, **kwargs)['counts']
+        no_query_total = sum([d['count'] for d in no_query_content_counts])
+        return {
+            'counts': combined_split_and_normalized_counts(matching_content_counts, no_query_content_counts),
+            'total': matching_total,
+            'normalized_total': no_query_total,
+        }
+
+    def _everything_query(self) -> str:
+        """
+        :return: a query string that can be used to capture matching "everything" 
+        """
+        return '*'

--- a/leadmanager/platforms/reddit.py
+++ b/leadmanager/platforms/reddit.py
@@ -1,0 +1,133 @@
+from collections import defaultdict
+import datetime as dt
+import requests
+from typing import List, Dict
+import logging
+
+from .provider import ContentProvider, MC_DATE_FORMAT
+#from ..util.cache import cache_by_kwargs
+
+REDDIT_PUSHSHIFT_URL = "https://beta.pushshift.io"
+SUBMISSION_SEARCH_URL = "{}/reddit/search/submissions".format(REDDIT_PUSHSHIFT_URL)
+
+NEWS_SUBREDDITS = ['politics', 'worldnews', 'news', 'conspiracy', 'Libertarian', 'TrueReddit', 'Conservative', 'offbeat']
+
+
+class RedditPushshiftProvider(ContentProvider):
+
+    def __init__(self):
+        super(RedditPushshiftProvider, self).__init__()
+        self._logger = logging.getLogger(__name__)
+
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20, **kwargs) -> List[Dict]:
+        """
+        Return a list of top submissions matching the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param limit:
+        :param kwargs: Options: 'subreddits': List[str]
+        :return:
+        """
+        data = self._cached_submission_search(q=query,
+                                              start_date=start_date, end_date=end_date,
+                                              limit=limit,  sort='score', order='desc', **kwargs)
+        cleaned_data = [self._submission_to_row(item) for item in data['data'][:limit]]
+        return cleaned_data
+
+    def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
+        """
+        Count how reddit sumissions match the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs: Options: 'subreddits': List[str]
+        :return:
+        """
+        data = self._cached_submission_search(q=query,
+                                              start_date=start_date, end_date=end_date,
+                                              limit=0, track_total_hits=True, **kwargs)
+        return data['metadata']['es']['hits']['total']['value']
+
+    def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
+        """
+        How many reddit submissions over time match the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs: Options: 'subreddits': List[str], period: str (default '1d')
+        :return:
+        """
+        period = kwargs['period'] if 'period' in kwargs else '1d'
+        data = self._cached_submission_search(q=query,
+                                              start_date=start_date, end_date=end_date,
+                                              calendar_histogram='day')
+        # make the results match the format we use for stories/count in the Media Cloud API
+        results = []
+        for d in data['metadata']['es']['aggregations']['calendar_histogram']['buckets']:
+            results.append({
+                'date': dt.datetime.fromtimestamp(d['key']/1000),
+                'timestamp': d['key']/1000,
+                'count': d['doc_count'],
+            })
+        return {'counts': results}
+
+    #@cache_by_kwargs()
+    def _cached_submission_search(self, query: str = None, start_date: dt.datetime = None, end_date: dt.datetime = None,
+                                  **kwargs) -> Dict:
+        """
+        Run a generic query against Pushshift.io to retrieve Reddit data
+        :param start_date:
+        :param end_date:
+        :param subreddits:
+        :param kwargs: any other params you want to send over the Pushshift as part of your query (sort, sort_type,
+        limit, aggs, etc)
+        :return:
+        """
+        headers = {'Content-type': 'application/json'}
+        params = defaultdict()
+        if query is not None:
+            params['q'] = query
+        if 'subreddits' in kwargs:
+            params['subreddit'] = ",".join(kwargs['subreddits'])
+        if (start_date is not None) and (end_date is not None):
+            params['since'] = int(start_date.timestamp())
+            params['until'] = int(end_date.timestamp())
+        # and now add in any other arguments they have sent in
+        params.update(kwargs)
+        r = requests.get(SUBMISSION_SEARCH_URL, headers=headers, params=params)
+        # temp = r.url # useful assignment for debugging investigations
+        return r.json()
+
+    @classmethod
+    def _submission_to_row(cls, item: Dict) -> Dict:
+        """
+        turn a Reddit submission into something that looks like a Media Cloud story
+        :param item:
+        :return:
+        """
+        return {
+            'media_name': '/r/{}'.format(item['subreddit']),
+            'media_url': 'https://reddit.com/r/{}'.format(item['subreddit']),
+            'url': 'https://reddit.com/'+item['permalink'],
+            'stories_id': item['id'],
+            'content': item['title'],
+            'publish_date': dt.datetime.fromtimestamp(item['created_utc']).strftime(MC_DATE_FORMAT),
+            'media_link': item['url'],
+            'score': item['score'],
+            'last_updated': dt.datetime.fromtimestamp(item['updated_utc']).strftime(MC_DATE_FORMAT) if 'updated_utc' in item else None,
+            'author': item['author'],
+            'subreddit': item['subreddit']
+        }
+
+    @classmethod
+    def _sanitize_url_for_reddit(cls, url: str) -> str:
+        """
+        Naive normalization, but works OK
+        :return:
+        """
+        return url.split('?')[0]
+
+    def _everything_query(self) -> str:
+        return ''
+

--- a/leadmanager/platforms/test/test_onlinenews.py
+++ b/leadmanager/platforms/test/test_onlinenews.py
@@ -1,0 +1,38 @@
+import unittest
+import datetime as dt
+
+from leadmanager.platforms.onlinenews import OnlineNewsMediaCloudProvider
+from leadmanager.platforms import MEDIA_CLOUD_API_KEY
+
+
+class OnlineNewsMediaCloudProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        self._provider = OnlineNewsMediaCloudProvider(MEDIA_CLOUD_API_KEY)
+
+    def test_count(self):
+        results = self._provider.count("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                        dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        assert results > 0
+
+    def test_sample(self):
+        results = self._provider.sample("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                        dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        for post in results:
+            assert 'url' in post
+
+    def test_count_over_time(self):
+        results = self._provider.count_over_time("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                                 dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        for item in results['counts']:
+            assert 'date' in item
+            assert 'count' in item
+
+    def test_normalized_count_over_time(self):
+        results = self._provider.normalized_count_over_time("Trump",
+                                                            dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                                            dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        assert 'counts' in results
+        assert 'total' in results
+        assert results['total'] > 0
+        assert 'normalized_total' in results

--- a/leadmanager/platforms/test/test_reddit.py
+++ b/leadmanager/platforms/test/test_reddit.py
@@ -1,0 +1,39 @@
+import unittest
+import datetime as dt
+
+from ..reddit import RedditPushshiftProvider
+
+
+class RedditPushshiftProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        self._provider = RedditPushshiftProvider()
+
+    def test_count(self):
+        results = self._provider.count("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                        dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        assert results > 0
+
+    def test_sample(self):
+        results = self._provider.sample("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                        dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        last_score = 9999999999999
+        for post in results:
+            assert last_score >= post['score']
+            last_score = post['score']
+
+    def test_count_over_time(self):
+        results = self._provider.count_over_time("Trump", dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                                 dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        for item in results['counts']:
+            assert 'date' in item
+            assert 'count' in item
+
+    def test_normalized_count_over_time(self):
+        results = self._provider.normalized_count_over_time("Trump",
+                                                            dt.datetime.strptime("2019-01-01", "%Y-%m-%d"),
+                                                            dt.datetime.strptime("2019-02-01", "%Y-%m-%d"))
+        assert 'counts' in results
+        assert 'total' in results
+        assert results['total'] > 0
+        assert 'normalized_total' in results

--- a/leadmanager/platforms/test/test_twitter.py
+++ b/leadmanager/platforms/test/test_twitter.py
@@ -1,0 +1,40 @@
+import unittest
+import datetime as dt
+
+from .. import TWITTER_API_BEARER_TOKEN
+from ..twitter import TwitterTwitterProvider
+
+TERM = "robots"
+
+
+class TwitterTwitterProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        self._provider = TwitterTwitterProvider(TWITTER_API_BEARER_TOKEN)
+
+    def test_sample(self):
+        results = self._provider.sample(TERM, start_date=dt.datetime.now() - dt.timedelta(days=5),
+                                        end_date=dt.datetime.now())
+        assert isinstance(results, list) is True
+        for tweet in results:
+            assert 'content' in tweet
+            assert len(tweet['content']) > 0
+
+    def test_count(self):
+        results = self._provider.count(TERM, start_date=dt.datetime.now() - dt.timedelta(days=5),
+                                       end_date=dt.datetime.now())
+        assert results > 0
+
+    def test_count_over_time(self):
+        results = self._provider.count_over_time(TERM, start_date=dt.datetime.now() - dt.timedelta(days=5),
+                                                 end_date=dt.datetime.now())
+        assert 'counts' in results
+        assert isinstance(results['counts'], list) is True
+        assert len(results['counts']) == 6
+
+    def test_longer_count_over_time(self):
+        results = self._provider.count_over_time(TERM, start_date=dt.datetime.now() - dt.timedelta(days=45),
+                                                 end_date=dt.datetime.now())
+        assert 'counts' in results
+        assert isinstance(results['counts'], list) is True
+        assert len(results['counts']) == 46

--- a/leadmanager/platforms/test/test_youtube.py
+++ b/leadmanager/platforms/test/test_youtube.py
@@ -1,0 +1,40 @@
+# pylint: disable=protected-access
+
+import unittest
+import datetime as dt
+
+from .. import YOUTUBE_API_KEY
+from ..youtube import YouTubeYouTubeProvider
+
+TERM = "robot"
+DAY_WINDOW = 100  # window in days to search for tem
+
+
+class YouTubeYouTubeProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        self._provider = YouTubeYouTubeProvider(YOUTUBE_API_KEY)
+
+    def test_fetch_results_from_api(self):
+        results = self._provider._fetch_results_from_api(
+            TERM,
+            start_date=dt.datetime.now() - dt.timedelta(days=DAY_WINDOW),
+            end_date=dt.datetime.now()
+        )
+        assert isinstance(results, dict) is True
+
+    def test_count(self):
+        results = self._provider.count(
+            TERM,
+            start_date=dt.datetime.now() - dt.timedelta(days=DAY_WINDOW),
+            end_date=dt.datetime.now()
+        )
+        assert (results == "> 1000000") or (results > 0)
+
+    def test_sample(self):
+        results = self._provider.sample(
+            TERM,
+            start_date=dt.datetime.now() - dt.timedelta(days=DAY_WINDOW),
+            end_date=dt.datetime.now()
+        )
+        assert isinstance(results, list) is True

--- a/leadmanager/platforms/twitter.py
+++ b/leadmanager/platforms/twitter.py
@@ -1,0 +1,141 @@
+import datetime as dt
+import requests
+import dateparser
+from typing import List, Dict
+import logging
+
+from .provider import ContentProvider
+#from ..util.cache import cache_by_kwargs
+from .exceptions import UnsupportedOperationException
+
+
+TWITTER_API_URL = 'https://api.twitter.com/2/'
+
+
+class TwitterTwitterProvider(ContentProvider):
+
+    def __init__(self, bearer_token=None):
+        super(TwitterTwitterProvider, self).__init__()
+        self._logger = logging.getLogger(__name__)
+        self._bearer_token = bearer_token
+
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 10, **kwargs) -> List[Dict]:
+        """
+        Return a list of historical tweets matching the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param limit:
+        :param kwargs:
+        :return:
+        """
+        # sample of historical tweets
+        params = {
+            "query": query,
+            "max_results": limit,
+            "start_time": start_date.isoformat("T") + "Z",
+            "end_time": end_date.isoformat("T") + "Z",
+            "tweet.fields": ",".join(["author_id", "created_at", "public_metrics"]),
+            "expansions": "author_id"
+        }
+        results = self._cached_query("tweets/search/all", params)
+        return TwitterTwitterProvider._tweets_to_rows(results)
+
+    def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
+        params = dict(
+            query=query,
+            granularity='day',
+            start_time=start_date.isoformat("T") + "Z",
+            end_time=end_date.isoformat("T") + "Z",
+        )
+        results = self._cached_query("tweets/counts/all", params)
+        return results['meta']['total_tweet_count']
+
+    def count_over_time(self, query: str, start_date: dt.datetime,
+                        end_date: dt.datetime,
+                        **kwargs) -> Dict:
+        """
+        Count how many tweets match the query over the 31 days before end_date.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs:
+        :return:
+        """
+        params = dict(
+            query=query,
+            granularity='day',
+            start_time=start_date.isoformat("T") + "Z",
+            end_time=end_date.isoformat("T") + "Z",
+        )
+        more_data = True
+        next_token = None
+        data = []
+        while more_data:
+            params['next_token'] = next_token
+            results = self._cached_query("tweets/counts/all", params)
+            data += reversed(results['data'])
+            if ('meta' in results) and ('next_token' in results['meta']):
+                next_token = results['meta']['next_token']
+                more_data = True
+            else:
+                next_token = None
+                more_data = False
+        to_return = []
+        for d in data:
+            to_return.append({
+                'date': dateparser.parse(d['start']),
+                'timestamp': dateparser.parse(d['start']).timestamp(),
+                'count': d['tweet_count'],
+            })
+        return {'counts': to_return}
+
+    #@cache_by_kwargs()
+    def _cached_query(self, endpoint: str, params: Dict = None) -> Dict:
+        """
+        Run a generic query agains the Twitter historical search API
+        :param endpoint:
+        :param query:
+        :param params:
+        :return:
+        """
+        headers = {
+            'Content-type': 'application/json',
+            'Authorization': "Bearer {}".format(self._bearer_token)
+        }
+        r = requests.get(TWITTER_API_URL+endpoint, headers=headers, params=params)
+        return r.json()
+
+    @classmethod
+    def _add_author_to_tweets(cls, results: Dict) -> None:
+        user_id_lookup = {u['id']: u for u in results['includes']['users']}
+        for t in results['data']:
+            t['author'] = user_id_lookup[t['author_id']]
+
+    @classmethod
+    def _tweets_to_rows(cls, results: Dict) -> List:
+        TwitterTwitterProvider._add_author_to_tweets(results)
+        return [TwitterTwitterProvider._tweet_to_row(t) for t in results['data']]
+
+    @classmethod
+    def _tweet_to_row(cls, item: Dict) -> Dict:
+        link = 'https://twitter.com/{}/status/{}'.format(item['author']['username'], item['id'])
+        return {
+            'media_name': 'Twitter',
+            'media_url': 'https://twitter.com/{}'.format(item['author']['username']),
+            'stories_id': item['id'],
+            'content': item['text'],
+            'publish_date': dateparser.parse(item['created_at']),
+            'url': link,
+            'last_updated': dateparser.parse(item['created_at']),
+            'author': item['author']['name'],
+            'language': None,
+            'retweet_count': item['public_metrics']['retweet_count'],
+            'reply_count': item['public_metrics']['reply_count'],
+            'like_count': item['public_metrics']['like_count'],
+            'quote_count': item['public_metrics']['quote_count'],
+        }
+
+    def normalized_count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                                   **kwargs) -> Dict:
+        raise UnsupportedOperationException("Can't search twitter for all tweets in a timeframe")

--- a/leadmanager/platforms/util.py
+++ b/leadmanager/platforms/util.py
@@ -1,0 +1,52 @@
+import datetime
+from operator import itemgetter
+import dateutil
+import mediacloud.api
+
+
+def _trim_solr_date(date_str):
+    return dateutil.parser.parse(date_str).strftime("%Y-%m-%d")
+
+
+def add_missing_dates_to_split_story_counts(counts, start, end, period="day"):
+    if start is None and end is None:
+        return counts
+    new_counts = []
+    current = start.date()
+    while current <= end.date():
+        date_string = current.strftime(mediacloud.api.MediaCloud.SENTENCE_PUBLISH_DATE_FORMAT)
+        existing_count = next((r for r in counts if r['date'] == date_string), None)
+        if existing_count:
+            new_counts.append(existing_count)
+        else:
+            new_counts.append({'date': date_string, 'count': 0})
+        if period == "day":
+            current += datetime.timedelta(days=1)
+        elif period == "month":
+            current += datetime.timedelta(days=30)
+        elif period == "year":
+            current += datetime.timedelta(days=365)
+        else:
+            raise RuntimeError("Unsupport time period for filling in missing dates - {}".format(period))
+    return new_counts
+
+
+def combined_split_and_normalized_counts(matching_results, total_results):
+    counts = []
+    for day in total_results:
+        day_info = {
+            'date': day['date'],
+            'total_count': day['count']
+        }
+        matching = [d for d in matching_results if d['date'] == day['date']]
+        if len(matching) == 0:
+            day_info['count'] = 0
+        else:
+            day_info['count'] = matching[0]['count']
+        if day_info['count'] == 0 or day['count'] == 0:
+            day_info['ratio'] = 0
+        else:
+            day_info['ratio'] = float(day_info['count']) / float(day['count'])
+        counts.append(day_info)
+    counts = sorted(counts, key=itemgetter('date'))
+    return counts

--- a/leadmanager/platforms/youtube.py
+++ b/leadmanager/platforms/youtube.py
@@ -1,0 +1,104 @@
+import datetime as dt
+from typing import List, Dict
+import logging
+import dateutil.parser
+import requests
+
+#from ..util.cache import cache_by_kwargs
+from .provider import ContentProvider, MC_DATE_FORMAT
+from .exceptions import UnsupportedOperationException
+
+# 2014-09-21T00:00:00Z
+YT_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+YT_SEARCH_API_URL = 'https://www.googleapis.com/youtube/v3/search'
+
+#YT_SEARCH_API_URL = 'https://content-youtube.googleapis.com/youtube/v3/search'
+YT_SEARCH_HEADERS = {
+    "x-origin": "https://explorer.apis.google.com",
+    "x-referer": "https://explorer.apis.google.com",
+}
+
+
+class YouTubeYouTubeProvider(ContentProvider):
+    """
+    Get matching YouTube videos
+    """
+
+    def __init__(self, api_key):
+        super(YouTubeYouTubeProvider, self).__init__()
+        self._logger = logging.getLogger(__name__)
+        self._api_key = api_key
+
+    def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
+        raise UnsupportedOperationException("Can't search youtube for videos poseted over time")
+
+    def count(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> int:
+        """
+        Count how many videos match the query.
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param kwargs:
+        :return:
+        """
+        results = self._fetch_results_from_api(query, start_date, end_date)
+        total = results['pageInfo']['totalResults']
+        if total == 1000000:
+            total = "> 1000000"
+        return total
+
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20,
+               **kwargs) -> List[Dict]:
+        """
+        :param query:
+        :param start_date:
+        :param end_date:
+        :param limit:
+        :param kwargs:
+        :return:
+        """
+        results = self._fetch_results_from_api(query, start_date, end_date, limit, order="viewCount")
+        # make sure we pull out only the videos (even through we requested only videos
+        videos = []
+        for search_result in results['items']:
+            if search_result["id"]["kind"] == "youtube#video":
+                videos.append(search_result)
+        # format them like stories to return
+        stories = [self._content_to_row(v) for v in videos]
+        return stories
+
+    @classmethod
+    def _content_to_row(cls, item):
+        try:
+            publish_date = dateutil.parser.parse(item['snippet']['publishedAt']).strftime(MC_DATE_FORMAT)
+        except ValueError:
+            publish_date = None
+        except KeyError:
+            publish_date = None
+        return {
+            'stories_id': item['id']['videoId'],
+            'author': item['snippet']['channelTitle'],
+            'publish_date': publish_date,
+            'content': item['snippet']['title'],
+            'media_name': item['snippet']['channelTitle'],
+            'media_url': "https://www.youtube.com/channel/{}".format(item['snippet']['channelId']),
+            'url': "https://www.youtube.com/watch?v={}".format(item['id']['videoId'])
+        }
+
+    #@cache_by_kwargs()
+    def _fetch_results_from_api(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                                limit: int = 20, order: str = "relevance", page_token: str = None) -> dict:
+        params = {
+            'key': self._api_key,
+            'q': query,
+            'publishedAfter': start_date.strftime(YT_DATE_FORMAT),
+            'publishedBefore': end_date.strftime(YT_DATE_FORMAT),
+            'type': 'video',
+            'part': 'snippet, id',
+            'maxResults': limit,
+            'order': order,
+            'pageToken': page_token,
+        }
+        response = requests.get(YT_SEARCH_API_URL, headers=YT_SEARCH_HEADERS, params=params)
+        return response.json()

--- a/leadmanager/util/cache.py
+++ b/leadmanager/util/cache.py
@@ -1,0 +1,33 @@
+from django.core.cache import cache
+
+# provide helpers for working with Django's caching
+# adapted from https://james.lin.net.nz/2011/09/08/python-decorator-caching-your-functions/
+
+
+# get the cache key for storage
+def _cache_get_key(*args, **kwargs):
+    import hashlib
+    serialise = []
+    for arg in args:
+        serialise.append(str(arg))
+    for key, arg in kwargs.items():
+        serialise.append(str(key))
+        serialise.append(str(arg))
+    key = hashlib.md5("".join(serialise).encode("UTF8")).hexdigest()
+    return key
+
+
+# decorator for caching functions (default to one day)
+def cache_by_kwargs(time_secs: int = 60*60*24):
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            key = _cache_get_key(fn.__name__, *args, **kwargs)
+            result = cache.get(key)
+            if not result:
+                result = fn(*args, **kwargs)
+                cache.set(key, result, time_secs)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,9 @@ django-rest-knox==4.2.*
 psycopg2==2.9.*
 djangorestframework-simplejwt[crypto]==5.2.*
 pyhumps==3.7.*
+django-environ==0.9.*
+dj-database-url==0.5.*
+mediacloud==3.13.*
+python-dateutil==2.8.*
+dateparser==1.1.*
+pymemcache==3.5.*


### PR DESCRIPTION
Once you merge this you'll need to `pip install -r requirements.txt`, and also see the note below about env-vars. Once you have a query interface ready, you can wire in the Media Cloud API as described below to actually run a query and return data.

### Env Vars
For deployment and development it is better to keep computer-specific configuration in env-vars. This includes things like database connection strings, cookie seed secrets, API keys, etc. This PR adds a library (`django-environ`, `dj-database-url`) to do that and tweaks settings.py to read from it. You'll need to copy `leadmanager/.env.template` to `leadmanager/.env` and edit it. Just fill-in your MC API key for now, you can ignore the other platform options.

### Querying Media Cloud
This also adds a Django "app" for querying platforms. For now use the Media Cloud provider (`leadmanager.platforms.onlinenews.OnlineNewsMediaCloudProvider`). You can call it like this in a view:
```python
import json
from django.http import HttpResponse
from leadmanager.platforms import provider_for, PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD

def my_view():
    provider = provider_for(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD)
    total_articles = provider.count(query_str, start_date, end_date)
    return HttpResponse(json.dumps({"count": total_articles}), content_type="application/json")
```

This has the skeleton of a caching mechanism to cache results of duplicated queries, but I didn't fully integrate it because we haven't setup Django caching yet.
